### PR TITLE
FIX : Name Field validation in Contact us page

### DIFF
--- a/frontend/src/pages/Contact/Contact.js
+++ b/frontend/src/pages/Contact/Contact.js
@@ -23,6 +23,9 @@ function Contact() {
             id="exampleFormControlInput1"
             placeholder="Enter your Name"
             required
+             pattern="[a-zA-Z ]+"
+             oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed)"
+             oninput="this.setCustomValidity('')"
           />
         </div>
         <div className="mb-4">


### PR DESCRIPTION
### 📋 Description
The "Name" field in the **Contact us** page only accepts alphabetical letters (a-z, A-Z). Currently, the field does not allow users to input symbols and special characters, which may lead to invalid or spam submissions.

# Fix : #363

# Screenshot 
Before 
![image](https://github.com/user-attachments/assets/240394cc-3d2a-4ab7-b529-dd32caca5253)

After 
![image](https://github.com/user-attachments/assets/f5064e0e-c407-462a-83f2-bc6fde485a5b)

# Priority : 
High 💥

# Checklist
- [x] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.
