### PR TITLE
 Added gap between footer and faqs section

### DIFF
--- a/frontend/src/components/Footer/footer.css
+++ b/frontend/src/components/Footer/footer.css
@@ -6,7 +6,7 @@
   position: relative;
   z-index: 1;
   margin-top: 30px;
-  width: 99.5vw
+  width: 99.5vw;
 }
 
 .footer-content {

--- a/frontend/src/components/Quiz/Quiz.css
+++ b/frontend/src/components/Quiz/Quiz.css
@@ -5,8 +5,6 @@
     margin: 0 auto;
     text-align: center;
     font-family: 'Arial', sans-serif;
-   
-
   }
   
   .score-section {

--- a/frontend/src/pages/Home/Faqs.css
+++ b/frontend/src/pages/Home/Faqs.css
@@ -8,6 +8,7 @@
   background-color: #f9f9f9;
   border-radius: 10px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  margin-bottom: 43px;
 }
 
 .faqs-title {


### PR DESCRIPTION

#### Problem
The FAQs page was touching the footer section, resulting in an unappealing layout with no space between the content and the footer. This layout issue affected readability and user experience.

#### Solution
To fix this, I added a bottom margin to the FAQs page, creating adequate spacing between the page content and the footer. This adjustment improves the visual structure and enhances readability.

#### Changes Made
- Added a CSS margin to the bottom of the FAQs page.
- Tested the changes to confirm consistent spacing across various screen sizes.

![{A9DCCBB6-6B2C-4C93-A066-91EF016946C4}](https://github.com/user-attachments/assets/d5805eac-39ef-492c-b8c6-9cf2352cf706)
