### PR TITLE
🛠️FIX : Extra loan button in navbar

### DIFF
--- a/frontend/src/components/Navbar/Navbar.js
+++ b/frontend/src/components/Navbar/Navbar.js
@@ -9,7 +9,6 @@ const navItems = [
   { path: "/about", label: "About Us" },
   { path: "/contact", label: "Contact Us" },
   { path: "/loan", label: "Loan" },
-  { path: "/", label: "Loan" },
   { path: "/contributors", label: "Contributors" },
 ];
 


### PR DESCRIPTION
# Description 
There is no Extra loan button in the navbar anymore. 

 ## Fixes : #528 , #522 
## Closes : #528 , #522 

## Screenshot 

## Before
![image](https://github.com/user-attachments/assets/1ce95a5d-8065-42f6-af48-80bba56c4a17)


## After
![image](https://github.com/user-attachments/assets/4aef4131-c0ed-4bc3-a5fc-e50ed90408c4)


