### PR TITLE
Fix #470:Gallery Card Issue

### DIFF
--- a/frontend/src/pages/About/About.css
+++ b/frontend/src/pages/About/About.css
@@ -43,7 +43,7 @@
 .swiper-slide {
 	background-position: center;
 	background-size: cover;
-	width: 300px;
+	width: 450px;
 	background-color: #fff;
 	overflow: hidden;
 	border-radius: 15px;


### PR DESCRIPTION
Updated the CSS issue of gallery card in about page.Title of the card was not fully visible and it was cropping because of the width of the card.

Before Changes made:
![Screenshot 2024-11-16 145517](https://github.com/user-attachments/assets/2b73c135-9ab4-474a-bf93-3f5100299a20)

After Changes made:
![Screenshot 2024-11-16 145600](https://github.com/user-attachments/assets/7ed4e6c5-ee21-4c95-bd00-c6105b567b99)
