### PR TITLE
Fix: Prevent invalid characters in loan calculator input fields

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "mdb-react-ui-kit": "^9.0.0",
         "mongoose": "^8.7.0",
         "nodemon": "^3.1.7",
-        "react": "^18.3.1",
+        "react": "^18.2.0",
         "react-bootstrap": "^2.10.5",
         "react-dom": "^18.3.1",
         "react-firebase-hooks": "^5.1.1",
@@ -23756,9 +23756,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -23766,7 +23766,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/src/pages/Loan/Loan.css
+++ b/frontend/src/pages/Loan/Loan.css
@@ -152,7 +152,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  align-items: center; /* Center align items */
 }
 
 .loan-button {

--- a/frontend/src/pages/Loan/Loan.js
+++ b/frontend/src/pages/Loan/Loan.js
@@ -107,10 +107,16 @@ const Loan = () => {
                             type="number"
                             value={loanAmount}
                             onChange={(e) => setLoanAmount(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (["e", "E", "+", "-"].includes(e.key)) {
+                                    e.preventDefault();
+                                }
+                            }}
                             placeholder="Enter amount"
                             required
                         />
                     </label>
+
                     <label htmlFor="interestRate">
                         Annual Interest Rate (%):
                         <input
@@ -118,10 +124,16 @@ const Loan = () => {
                             type="number"
                             value={interestRate}
                             onChange={(e) => setInterestRate(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (["e", "E", "+", "-"].includes(e.key)) {
+                                    e.preventDefault();
+                                }
+                            }}
                             placeholder="Enter rate"
                             required
                         />
                     </label>
+
                     <label htmlFor="loanTerm">
                         Loan Term (years):
                         <input
@@ -129,10 +141,16 @@ const Loan = () => {
                             type="number"
                             value={loanTerm}
                             onChange={(e) => setLoanTerm(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (["e", "E", "+", "-"].includes(e.key)) {
+                                    e.preventDefault();
+                                }
+                            }}
                             placeholder="Enter term"
                             required
                         />
                     </label>
+                    
                     <label htmlFor="paymentFrequency">
                         Payment Frequency:
                         <select


### PR DESCRIPTION
## Description
This PR fixes a bug in the Loan Calculator input fields where invalid characters (`e`, `E`, `+`, `-`) could be entered in number inputs.

## Bug
- Steps to Reproduce:
  1. Go to `/loan` page.
  2. Try typing `e` or `E` in Loan Amount, Interest Rate, or Loan Term input fields.
  3. The input accepts them, but these are not valid numbers.

- Expected Behavior:
  Only numeric values (digits) should be allowed.

## Fix
- Added an `onKeyDown` handler to prevent `e`, `E`, `+`, `-` from being typed in:
  - Loan Amount
  - Interest Rate
  - Loan Term

```jsx
onKeyDown={(e) => {
  if (["e", "E", "+", "-"].includes(e.key)) {
    e.preventDefault();
  }
}}

Closes issue no. #567 