### PR TITLE
Layout fix on signup page

### DIFF
--- a/frontend/src/components/Signup/Signup.js
+++ b/frontend/src/components/Signup/Signup.js
@@ -160,7 +160,10 @@ function Signup() {
           }
         `}
       </style>
-      <div className="container mx-auto mt-5 flex flex-col justify-center bg-cyan-500" style={{ height: "auto" }}>
+
+      <div className="justify-content-center align-items-center bg-cyan-500 ">
+      <div className=" mt-5">
+     
         <div className="row justify-content-center" style={{ width: "100%" }}>
           <div className="col-md-6">
             <div className="card shadow signup-card">
@@ -270,7 +273,10 @@ function Signup() {
             </div>
           </div>
         </div>
-        <Footer />
+      
+     
+      </div>
+       <Footer />
       </div>
     </>
   );


### PR DESCRIPTION
Fixed issue:   https://github.com/Vin205/Enyanjyoti/issues/570

the Signup card and the Footer appear side by side instead of stacking vertically (Signup followed by Footer). My code fixes this issue and now the footer is properly aligned at the bottom.

![WhatsApp Image 2025-10-09 at 11 03 49](https://github.com/user-attachments/assets/08fce64a-2fa9-4ea9-93d7-4ce80cc436e9)

![WhatsApp Image 2025-10-09 at 11 04 03](https://github.com/user-attachments/assets/153d8819-4595-436f-a1cf-595fbbe3e8f9)
